### PR TITLE
Fix misinterpretation of multiple "rel" attributes rule in RFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,17 @@ link.has( 'rel', 'alternate' )
 **Retrieve a reference with a given attribute & value**
 
 ```js
-link.get( 'title', 'alternate' )
-> { uri: 'example-01.com', rel: 'alternate', title: 'Alternate Example Domain' }
+link.get( 'rel', 'alternate' )
+> [
+  { uri: 'example-01.com', rel: 'alternate', title: 'Alternate Example Domain' }
+]
+```
+```js
 // Shorthand for `rel` attributes
 link.rel( 'alternate' )
-> { uri: 'example-01.com', rel: 'alternate', title: 'Alternate Example Domain' }
+> [
+  { uri: 'example-01.com', rel: 'alternate', title: 'Alternate Example Domain' }
+]
 ```
 
 **Set references**
@@ -66,15 +72,32 @@ link.set({ rel: 'next', uri: 'http://example.com/next' })
 }
 ```
 
-NOTE: According to [RFC 5988] only one reference with the same `rel` attribute is allowed,
-so the following effectively replaces an existing reference:
+**Parse multiple headers**
 
-```js
-link.set({ uri: 'http://not-example.com', rel: 'example' })
+```
+var links = new LinkHeader()
+
+links.parse( '<example.com>; rel="example"; title="Example Website"' )
 > Link {
   refs: [
-    { uri: 'http://not-example.com', rel: 'example' },
+    { uri: 'example.com', rel: 'example', title: 'Example Website' },
+  ]
+}
+
+links.parse( '<example-01.com>; rel="alternate"; title="Alternate Example Domain"' )
+> Link {
+  refs: [
+    { uri: 'example.com', rel: 'example', title: 'Example Website' },
     { uri: 'example-01.com', rel: 'alternate', title: 'Alternate Example Domain' },
+  ]
+}
+
+links.parse( '<example-02.com>; rel="alternate"; title="Second Alternate Example Domain"' )
+> Link {
+  refs: [
+    { uri: 'example.com', rel: 'example', title: 'Example Website' },
+    { uri: 'example-01.com', rel: 'alternate', title: 'Alternate Example Domain' },
+    { uri: 'example-02.com', rel: 'alternate', title: 'Second Alternate Example Domain' },
   ]
 }
 ```

--- a/lib/link.js
+++ b/lib/link.js
@@ -114,6 +114,31 @@ Link.parseExtendedValue = function( value ) {
 }
 
 /**
+ * Set an attribute on a link ref
+ * @param {Object} link
+ * @param {String} attr
+ * @param {String} value
+ */
+Link.setAttr = function( link, attr, value ) {
+
+  // Occurrences after the first "rel" MUST be ignored by parsers
+  // @see RFC 5988, Section 5.3: Relation Type
+  if( attr === 'rel' && link[ attr ] != null )
+    return link
+
+  if( Array.isArray( link[ attr ] ) ) {
+    link[ attr ].push( value )
+  } else if( link[ attr ] != null ) {
+    link[ attr ] = [ link[ attr ], value ]
+  } else {
+    link[ attr ] = value
+  }
+
+  return link
+
+}
+
+/**
  * Parses out URI attributes
  * @internal
  * @param {Object} link
@@ -123,18 +148,18 @@ Link.parseExtendedValue = function( value ) {
 Link.parseAttrs = function( link, parts ) {
 
   var match = null
-  var key = ''
+  var attr = ''
   var value = ''
 
   while( match = Link.attrPattern.exec( parts ) ) {
-    key = match[1].toLowerCase()
+    attr = match[1].toLowerCase()
     value = match[4] || match[3] || match[2]
-    if( /\*$/.test( key ) ) {
-      link[ key ] = Link.parseExtendedValue( value )
+    if( /\*$/.test( attr ) ) {
+      Link.setAttr( link, attr, Link.parseExtendedValue( value ) )
     } else if( /%/.test( value ) ) {
-      link[ key ] = querystring.unescape( value )
+      Link.setAttr( link, attr, querystring.unescape( value ) )
     } else {
-      link[ key ] = value
+      Link.setAttr( link, attr, value )
     }
   }
 
@@ -154,36 +179,50 @@ Link.prototype = {
 
   constructor: Link,
 
+  /**
+   * Get refs with given relation type
+   * @param {String} value
+   * @return {Array<Object>}
+   */
   rel: function( value ) {
+
+    var links = []
+
     for( var i = 0; i < this.refs.length; i++ ) {
       if( this.refs[ i ].rel === value ) {
-        return this.refs[ i ]
+        links.push( this.refs[ i ] )
       }
     }
+
+    return links
+
   },
 
+  /**
+   * Get refs where given attribute has a given value
+   * @param {String} attr
+   * @param {String} value
+   * @return {Array<Object>}
+   */
   get: function( attr, value ) {
 
     attr = attr.toLowerCase()
 
+    var links = []
+
     for( var i = 0; i < this.refs.length; i++ ) {
       if( this.refs[ i ][ attr ] === value ) {
-        return this.refs[ i ]
+        links.push( this.refs[ i ] )
       }
     }
+
+    return links
 
   },
 
   set: function( link ) {
-
-    var old = this.rel( link.rel )
-
-    old != null ?
-      this.refs.splice( this.refs.indexOf( old ), 1, link ) :
-      this.refs.push( link )
-
+    this.refs.push( link )
     return this
-
   },
 
   has: function( attr, value ) {
@@ -200,7 +239,6 @@ Link.prototype = {
 
     while( match = Link.pattern.exec( value ) ) {
       var link = Link.parseAttrs({ uri: match[1] }, match[0] )
-      if( this.rel( link.rel ) != null ) continue;
       this.refs.push( link )
     }
 

--- a/test/api.js
+++ b/test/api.js
@@ -7,7 +7,7 @@ suite( 'API', function() {
   test( 'get("rel", "next")', function() {
     var link = Link.parse( '<https://acme-staging.api.letsencrypt.org/acme/new-authz>;rel="next", <https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf>;rel="terms-of-service"' )
     // console.log( inspect( link.get( 'rel', 'next' ) ) )
-    assert.deepEqual( link.get( 'rel', 'next' ), {
+    assert.deepEqual( link.get( 'rel', 'next' )[0], {
       uri: 'https://acme-staging.api.letsencrypt.org/acme/new-authz',
       rel: 'next'
     })
@@ -16,7 +16,7 @@ suite( 'API', function() {
   test( 'rel("next")', function() {
     var link = Link.parse( '<https://acme-staging.api.letsencrypt.org/acme/new-authz>;rel="next", <https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf>;rel="terms-of-service"' )
     // console.log( inspect( link.ret( 'next' ) ) )
-    assert.deepEqual( link.rel( 'next' ), {
+    assert.deepEqual( link.rel( 'next' )[0], {
       uri: 'https://acme-staging.api.letsencrypt.org/acme/new-authz',
       rel: 'next'
     })
@@ -34,7 +34,7 @@ suite( 'API', function() {
     assert.equal( link.toString(), expected )
   })
 
-  test( 'set( add )', function() {
+  test( 'set()', function() {
     var link = Link.parse( '<https://acme-staging.api.letsencrypt.org/acme/new-authz>;rel="next", <https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf>;rel="terms-of-service"' )
     link.set({
       uri: 'https://github.com/ietf-wg-acme/acme/',
@@ -42,24 +42,69 @@ suite( 'API', function() {
     })
     // console.log( inspect( link ) )
     assert.equal( link.refs.length, 3 )
-    assert.deepEqual( link.get( 'rel', 'example' ), {
+    assert.deepEqual( link.get( 'rel', 'example' )[0], {
       uri: 'https://github.com/ietf-wg-acme/acme/',
       rel: 'example'
     })
   })
 
-  test( 'set( overwrite )', function() {
+  test( 'set()', function() {
     var link = Link.parse( '<https://acme-staging.api.letsencrypt.org/acme/new-authz>;rel="next", <https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf>;rel="terms-of-service"' )
     link.set({
       uri: 'https://not-the-same.com/',
       rel: 'next'
     })
     // console.log( inspect( link ) )
-    assert.equal( link.refs.length, 2 )
-    assert.deepEqual( link.get( 'rel', 'next' ), {
+    assert.equal( link.refs.length, 3 )
+    assert.equal( link.get( 'rel', 'next' ).length, 2 )
+    assert.deepEqual( link.get( 'rel', 'next' )[1], {
       uri: 'https://not-the-same.com/',
       rel: 'next'
     })
+  })
+
+  test( 'set()', function() {
+    var link = Link.parse( '<https://acme-staging.api.letsencrypt.org/acme/new-authz>;rel="next", <https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf>;rel="terms-of-service"' )
+    link.set({
+      uri: 'https://not-the-same.com/',
+      rel: 'next'
+    })
+    // console.log( inspect( link ) )
+    assert.equal( link.refs.length, 3 )
+    assert.deepEqual( link.get( 'rel', 'next' )[0], {
+      uri: 'https://acme-staging.api.letsencrypt.org/acme/new-authz',
+      rel: 'next'
+    })
+  })
+
+  test( 'parse() multiple', function() {
+
+    var links = new Link()
+
+    links.parse( '<example.com>; rel="example"; title="Example Website"' )
+    assert.deepEqual( links, {
+      refs: [
+        { uri: 'example.com', rel: 'example', title: 'Example Website' },
+      ]
+    })
+
+    links.parse( '<example-01.com>; rel="alternate"; title="Alternate Example Domain"' )
+    assert.deepEqual( links, {
+      refs: [
+        { uri: 'example.com', rel: 'example', title: 'Example Website' },
+        { uri: 'example-01.com', rel: 'alternate', title: 'Alternate Example Domain' },
+      ]
+    })
+
+    links.parse( '<example-02.com>; rel="alternate"; title="Second Alternate Example Domain"' )
+    assert.deepEqual( links, {
+      refs: [
+        { uri: 'example.com', rel: 'example', title: 'Example Website' },
+        { uri: 'example-01.com', rel: 'alternate', title: 'Alternate Example Domain' },
+        { uri: 'example-02.com', rel: 'alternate', title: 'Second Alternate Example Domain' },
+      ]
+    })
+
   })
 
 })

--- a/test/index.js
+++ b/test/index.js
@@ -48,7 +48,7 @@ suite( 'HTTP Link Header', function() {
   // The "rel" parameter MUST NOT appear more than once in a given
   // link-value; occurrences after the first MUST be ignored by parsers.
   test( 'multiple links with same rel', function() {
-    var link = Link.parse( '<example.com>; rel="example", <example-01.com>; rel="example"' )
+    var link = Link.parse( '<example.com>; rel="example"; rel="invalid"' )
     var refs = [
       { uri: 'example.com', rel: 'example' },
     ]


### PR DESCRIPTION
**Description:**
I was a bit dense, and didn't understand the RFC properly in one particular section;
For details, please see #7 

**Changes:**
- Change `.get()` and `.rel()` to return Arrays, as there can be several link-values with the same "rel" attribute
- Change `.set()` and `.parse()` to not ignore same "rel" refs
- Add `Link.setAttr( link, attr, value )` to handle setting attributes on link ref objects while respecting their cardinality (only one uri ref, only one "rel" attribute, everything else possibly multiple)
- Link ref objects (`link.refs[i]`) now can have arrays under their attribute keys, as multiple attributes with the same name can result in that
- Add tests to check against the spec
- Update the README to reflect the changes in API
