### PR TITLE
Correctly parse uri with parameters in the link

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -139,6 +139,24 @@ Link.setAttr = function( link, attr, value ) {
 }
 
 /**
+ * Parses uri attributes
+ */
+Link.parseParams = function( link, uri ) {
+  var kvs = {}
+  var params = /(.+)\?(.+)/gi.exec( uri )
+  if( !params ) {
+    return link
+  }
+  params = params[2].split('&')
+  for( var i = 0; i < params.length; i++ ) {
+    var param = params[i].split('=');
+    kvs[ param[0] ] = param[1]
+  }
+  Link.setAttr( link, 'params', kvs )
+  return link
+}
+
+/**
  * Parses out URI attributes
  * @internal
  * @param {Object} link
@@ -150,8 +168,15 @@ Link.parseAttrs = function( link, parts ) {
   var match = null
   var attr = ''
   var value = ''
+  var attrs = ''
 
-  while( match = Link.attrPattern.exec( parts ) ) {
+  var uriAttrs = /<(.*)>;\s*(.*)/gi.exec( parts )
+  if( uriAttrs ) {
+    attrs = uriAttrs[2]
+    link = Link.parseParams( link, uriAttrs[1] )
+  }
+
+  while( match = Link.attrPattern.exec( attrs ) ) {
     attr = match[1].toLowerCase()
     value = match[4] || match[3] || match[2]
     if( /\*$/.test( attr ) ) {

--- a/test/in-the-wild.js
+++ b/test/in-the-wild.js
@@ -17,4 +17,25 @@ suite( 'Link Headers In the Wild', function() {
     assert.deepEqual( link.refs, refs )
   })
 
+  test( 'GitHub pagination links', function() {
+    var link = Link.parse( '<https://api.github.com/user/repos?page=3&per_page=100>; rel="next", <https://api.github.com/user/repos?page=50&per_page=100>; rel="last"' )
+    var refs = [{
+      uri: 'https://api.github.com/user/repos?page=3&per_page=100',
+      rel: 'next',
+      params: {
+        page: "3",
+        per_page: "100",
+      }
+    }, {
+      uri: 'https://api.github.com/user/repos?page=50&per_page=100',
+      rel: 'last',
+      params: {
+        page: "50",
+        per_page: "100",
+      }
+    }]
+    // console.log( inspect( link ) )
+    assert.deepEqual( link.refs, refs )
+  })
+
 })


### PR DESCRIPTION
The current implementation does not take in account eventual parameters in the URI, like in GitHub APIs and similar. (example: https://developer.github.com/v3/#pagination )

This PR "splits" the link attributes from the uri in order to correctly process them and put all uri parameters into a separate key 'params' in the link ref.

I've added an additional test to demonstrate the issue and relative fix.