### PR TITLE
Make the get method work with multiple rels

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -243,7 +243,7 @@ Link.prototype = {
     var links = []
 
     for( var i = 0; i < this.refs.length; i++ ) {
-      if( this.refs[ i ][ attr ] === value ) {
+      if( this.refs[ i ][ attr ] && this.refs[ i ][ attr ].split( /\s+/ ).indexOf( value ) !== -1 ) {
         links.push( this.refs[ i ] )
       }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -56,4 +56,12 @@ suite( 'HTTP Link Header', function() {
     assert.deepEqual( link.refs, refs )
   })
 
+  test( 'link with multiple rels', function() {
+    var link = Link.parse( '<https://webmention.rocks/test/10/webmention>; rel="webmention somethingelse"' )
+    assert.deepEqual( link.get( 'rel', 'webmention' )[0], {
+      uri: 'https://webmention.rocks/test/10/webmention',
+      rel: 'webmention somethingelse'
+    })
+  })
+
 })


### PR DESCRIPTION
The spec allows multiple relations on a single link, it makes sense for the `get` method to return links where the specified rel is just one of many.