### PR TITLE
Better has()

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -74,7 +74,7 @@ class Link {
    * Get refs where given attribute has a given value
    * @param {String} attr
    * @param {String} value
-   * @returns {Array<Object>|null}
+   * @returns {Array<Object>}
    */
   get( attr, value ) {
 
@@ -88,7 +88,7 @@ class Link {
       }
     }
 
-    return links.length ? links : null
+    return links
 
   }
 
@@ -98,7 +98,17 @@ class Link {
   }
 
   has( attr, value ) {
-    return this.get( attr, value ) != null
+
+    attr = attr.toLowerCase()
+
+    for( var i = 0; i < this.refs.length; i++ ) {
+      if( this.refs[ i ][ attr ] === value ) {
+        return true
+      }
+    }
+
+    return false
+
   }
 
   parse( value, offset ) {

--- a/test/api.js
+++ b/test/api.js
@@ -25,7 +25,13 @@ suite( 'API', function() {
   test( 'has("rel", "next")', function() {
     var link = Link.parse( '<https://acme-staging.api.letsencrypt.org/acme/new-authz>;rel="next", <https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf>;rel="terms-of-service"' )
     // console.log( inspect( link.has( 'rel', 'next' ) ) )
-    assert.deepEqual( link.has( 'next' ), true )
+    assert.deepEqual( link.has( 'rel', 'next' ), true )
+  })
+
+  test( 'has("rel", "prev")', function() {
+    var link = Link.parse( '<https://acme-staging.api.letsencrypt.org/acme/new-authz>;rel="next", <https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf>;rel="terms-of-service"' )
+    // console.log( inspect( link.has( 'rel', 'prev' ) ) )
+    assert.deepEqual( link.has( 'rel', 'prev' ), false )
   })
 
   test( 'toString()', function() {


### PR DESCRIPTION
* Cleanup `get()` (single return type) and improve `has()` happy-case performance
    * https://github.com/jhermsmeier/node-http-link-header/issues/14#issuecomment-443470506
* Fix `has()` test and add a test for the negative case