### PR TITLE
Allow an empty language section in extended header encoding.

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -301,7 +301,7 @@ Link.expandRelations = function( ref ) {
  * @return {Object}
  */
 Link.parseExtendedValue = function( value ) {
-  var parts = /([^']+)?(?:'([^']+)')?(.+)/.exec( value )
+  var parts = /([^']+)?(?:'([^']*)')?(.+)/.exec( value )
   return {
     language: parts[2].toLowerCase(),
     encoding: Link.isCompatibleEncoding( parts[1] ) ?

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -35,4 +35,18 @@ context( 'Encodings', function() {
     assert.deepEqual( link.refs, refs )
   })
 
+  test( 'language optional', function() {
+    var link = Link.parse( '</risk-mitigation>; rel="start"; title*=UTF-8\'\'%E2%91%A0%E2%93%AB%E2%85%93%E3%8F%A8%E2%99%B3%F0%9D%84%9E%CE%BB' )
+    var refs = [{
+      uri: '/risk-mitigation',
+      rel: 'start',
+      'title*': {
+        language: '',
+        encoding: null,
+        value: '①⓫⅓㏨♳𝄞λ'
+      },
+    }]
+    // console.log( inspect( link ) )
+    assert.deepEqual( link.refs, refs )
+  })
 })


### PR DESCRIPTION
[Section 3.2.1 of RFC 8187][rfc-s3.2.1] specifies that the language is optional in headers using extended encoding. One example given in section [3.2.3][rfc-s3.2.3] looks like:

```
foo: bar; title*=UTF-8''%c2%a3%20and%20%e2%82%ac%20rates
```

(the quotes are necessary delimiters, but the language is optional and in this case missing).

This PR adjusts the relevant regular expression to allow an empty string in this segment and adds a companion test.

[rfc-s3.2.1]: https://datatracker.ietf.org/doc/html/rfc8187#section-3.2.1
[rfc-s3.2.3]: https://datatracker.ietf.org/doc/html/rfc8187#section-3.2.3