### PR TITLE
Implement a class `Link` method `setUnique`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+- Added the class `Link` method `setUnique` ([@jaydenseric])
+
 ## v1.0.5
 
 - Allow an empty language section in extended header encoding. ([@qubyte])
@@ -47,3 +51,4 @@
 [@dhui]: https://github.com/dhui
 [@qubyte]: https://github.com/qubyte
 [@angelo-v]: https://github.com/angelo-v
+[@jaydenseric]: https://github.com/jaydenseric

--- a/README.md
+++ b/README.md
@@ -71,12 +71,40 @@ link.rel( 'alternate' )
 ### Setting references
 
 ```js
-link.set({ rel: 'next', uri: 'http://example.com/next' })
+link.set({ uri: 'https://example.com/next', rel: 'next' })
 > Link {
   refs: [
     { uri: 'example.com', rel: 'example', title: 'Example Website' },
     { uri: 'example-01.com', rel: 'alternate', title: 'Alternate Example Domain' },
-    { rel: 'next', uri: 'http://example.com/next' }
+    { rel: 'next', uri: 'https://example.com/next' }
+  ]
+}
+```
+
+### Setting a unique reference
+
+```js
+link.setUnique({
+  uri: 'https://example.com/image.png',
+  rel: 'preload',
+  as: 'image',
+  type: 'image/png'
+})
+> Link {
+  refs: [
+    { uri: 'https://example.com/image.png', rel: 'preload', as: 'image', type: 'image/png' }
+  ]
+}
+
+link.setUnique({
+  uri: 'https://example.com/image.png',
+  rel: 'preload',
+  as: 'image',
+  type: 'image/png'
+})
+> Link {
+  refs: [
+    { uri: 'https://example.com/image.png', rel: 'preload', as: 'image', type: 'image/png' }
   ]
 }
 ```

--- a/lib/link.js
+++ b/lib/link.js
@@ -40,6 +40,21 @@ function needsQuotes( value ) {
     !TOKEN_PATTERN.test( value )
 }
 
+/**
+ * Shallow compares two objects to check if their properties match.
+ * @param {object} object1 First object to compare.
+ * @param {object} object2 Second object to compare.
+ * @returns {boolean} Do the objects have matching properties.
+ */
+function shallowCompareObjects( object1, object2 ) {
+  return (
+    Object.keys( object1 ).length === Object.keys( object2 ).length &&
+    Object.keys( object1 ).every(
+      ( key ) => key in object2 && object1[ key ] === object2[ key ]
+    )
+  );
+}
+
 class Link {
 
   /**
@@ -101,9 +116,23 @@ class Link {
 
   }
 
+  /** Sets a reference. */
   set( link ) {
     this.refs.push( link )
     return this
+  }
+
+  /**
+   * Sets a reference if a reference with similar properties isn’t already set.
+   */
+  setUnique( link ) {
+
+    if( !this.refs.some(( ref ) => shallowCompareObjects( ref, link )) ) {
+      this.refs.push( link )
+    }
+
+    return this
+
   }
 
   has( attr, value ) {

--- a/test/api.js
+++ b/test/api.js
@@ -84,6 +84,33 @@ context( 'API', function() {
     })
   })
 
+  test( 'setUnique()', function() {
+    var link = new Link()
+    link.setUnique( { uri: 'https://example.com/a', rel: 'preconnect' } )
+    assert.deepEqual(
+      link.refs,
+      [
+        { uri: 'https://example.com/a', rel: 'preconnect' }
+      ]
+    )
+    link.setUnique( { uri: 'https://example.com/b', rel: 'preconnect' } )
+    assert.deepEqual(
+      link.refs,
+      [
+        { uri: 'https://example.com/a', rel: 'preconnect' },
+        { uri: 'https://example.com/b', rel: 'preconnect' }
+      ]
+    )
+    link.setUnique( { uri: 'https://example.com/a', rel: 'preconnect' } )
+    assert.deepEqual(
+      link.refs,
+      [
+        { uri: 'https://example.com/a', rel: 'preconnect' },
+        { uri: 'https://example.com/b', rel: 'preconnect' }
+      ]
+    )
+  })
+
   test( 'parse() multiple', function() {
 
     var links = new Link()


### PR DESCRIPTION
This PR implements a class `Link` method `setUnique` that sets a reference if a reference with similar properties isn’t already set. This is very useful for avoiding adding redundant duplicate refs to a link, for example when using `rel='preload'`.

In every project I have used this package as a dependency I have had to create and use this utility function:

```js
/**
 * Sets a `Link` header link, skipping the operation if the same URI and `rel`
 * combination has already been set. It’s assumed that other attributes such as
 * `as` or `type` won’t vary for a given URI and `rel` combination.
 * @see [`http-link-header` on npm](https://npm.im/http-link-header).
 * @param {import("http-link-header")} linkHeader `LinkHeader` instance.
 * @param {import("http-link-header").Reference} ref Link config.
 */
export const linkHeaderSetUnique = (linkHeader, ref) => {
  if (
    !linkHeader.refs.some(({ uri, rel }) => rel === ref.rel && uri === ref.uri)
  )
    linkHeader.set(ref);
};
```

This PR goes a little further that that utility function with the `setUnique` method as it shallow compares all reference properties, not just `uri` and `rel`.