### PR TITLE
link: fix parsing links with `nopush`

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -202,7 +202,8 @@ class Link {
           continue
         }
         var end = value.indexOf( '=', offset )
-        if( end === -1 ) throw new Error( 'Expected attribute delimiter at offset ' + offset )
+        if( end === -1 ) end = value.indexOf( ';', offset )
+        if( end === -1 ) end = value.length
         var attr = trim( value.slice( offset, end ) ).toLowerCase()
         var attrValue = ''
         offset = end + 1

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,13 @@ context( 'HTTP Link Header', function() {
     assert.deepEqual( link.refs, refs )
   })
 
+  test( 'link with nopush', function() {
+    var link = Link.parse( '<example.com>; nopush' )
+    var refs = [ { uri: 'example.com', nopush: '' } ]
+    // inspect.log( link )
+    assert.deepEqual( link.refs, refs )
+  })
+
   test( 'link with quoted rel', function() {
     var link = Link.parse( '<example.com>; rel="example"' )
     var refs = [ { uri: 'example.com', rel: 'example' } ]


### PR DESCRIPTION
Fixes https://github.com/jhermsmeier/node-http-link-header/issues/29