### PR TITLE
Fix case insensitive relation type comparison for has and get

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -103,11 +103,12 @@ class Link {
   get( attr, value ) {
 
     attr = attr.toLowerCase()
+    value = value.toLowerCase()
 
     var links = []
 
     for( var i = 0; i < this.refs.length; i++ ) {
-      if( this.refs[ i ][ attr ] === value ) {
+      if( this.refs[ i ][ attr ].toLowerCase() === value ) {
         links.push( this.refs[ i ] )
       }
     }
@@ -138,9 +139,10 @@ class Link {
   has( attr, value ) {
 
     attr = attr.toLowerCase()
+    value = value.toLowerCase()
 
     for( var i = 0; i < this.refs.length; i++ ) {
-      if( this.refs[ i ][ attr ] === value ) {
+      if( this.refs[ i ][ attr ].toLowerCase() === value ) {
         return true
       }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -134,15 +134,39 @@ context( 'HTTP Link Header', function() {
     assert.strictEqual( link.toString(), expected )
   })
 
-  test( 'case sensitive relation types', function() {
+  test( 'case insensitive relation types includes', function() {
     var value = '<https://some.url>; rel="http://some.rel/caseSensitive"'
     var expected = '<https://some.url>; rel="http://some.rel/caseSensitive"'
     var refs = [ { uri: 'https://some.url', rel: 'http://some.rel/caseSensitive' } ]
     var link = Link.parse( value )
-    // Check that comparison is case-insensitive, as specified in RFC8288, Section 2.2.1
-    assert.deepEqual( link.rel( 'http://some.rel/casesensitive' ), refs )
+
+    // Check that comparison is case-insensitive, as specified in RFC8288, Sections 2.1.1, 2.1.2
+    assert.strictEqual( link.has( 'rel', 'http://some.rel/casesensitive' ), true )
     // Verify that re-serialization maintains input casing
     assert.strictEqual( link.toString(), expected )
   })
 
+  test( 'case insensitive relation types by reference', function() {
+    var value = '<https://some.url>; rel="http://some.rel/caseSensitive"'
+    var expected = '<https://some.url>; rel="http://some.rel/caseSensitive"'
+    var refs = [ { uri: 'https://some.url', rel: 'http://some.rel/caseSensitive' } ]
+    var link = Link.parse( value )
+
+    // Check that comparison is case-insensitive, as specified in RFC8288, Sections 2.1.1, 2.1.2
+    assert.deepEqual( link.get( 'rel', 'http://some.rel/casesensitive' ), refs )
+    // Verify that re-serialization maintains input casing
+    assert.strictEqual( link.toString(), expected )
+  })
+
+  test( 'case insensitive relation types by reference shorthand', function() {
+    var value = '<https://some.url>; rel="http://some.rel/caseSensitive"'
+    var expected = '<https://some.url>; rel="http://some.rel/caseSensitive"'
+    var refs = [ { uri: 'https://some.url', rel: 'http://some.rel/caseSensitive' } ]
+    var link = Link.parse( value )
+
+    // Check that comparison is case-insensitive, as specified in RFC8288, Section 2.1.1, 2.1.2
+    assert.deepEqual( link.rel( 'http://some.rel/casesensitive' ), refs )
+    // Verify that re-serialization maintains input casing
+    assert.strictEqual( link.toString(), expected )
+  })
 })


### PR DESCRIPTION
Case-insensitive comparison is required as per RFC8288, Sections 2.1.1, 2.1.2 for relation types.

While case insensitive comparison is working as intended for the retrieval shorthand (`rel`), it was not for lookup (`has`) or retrieving (`get`). This PR fixes that and includes the tests.

