### PR TITLE
Avoid TypeError when referenced attribute is undefined

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -85,7 +85,7 @@ class Link {
     var type = value.toLowerCase()
 
     for( var i = 0; i < this.refs.length; i++ ) {
-      if( this.refs[ i ].rel && this.refs[ i ].rel.toLowerCase() === type ) {
+      if( typeof this.refs[ i ].rel === 'string' && this.refs[ i ].rel.toLowerCase() === type ) {
         links.push( this.refs[ i ] )
       }
     }
@@ -108,7 +108,7 @@ class Link {
     var links = []
 
     for( var i = 0; i < this.refs.length; i++ ) {
-      if( this.refs[ i ][ attr ] && this.refs[ i ][ attr ].toLowerCase() === value ) {
+      if( typeof this.refs[ i ][ attr ] === 'string' && this.refs[ i ][ attr ].toLowerCase() === value ) {
         links.push( this.refs[ i ] )
       }
     }
@@ -142,7 +142,7 @@ class Link {
     value = value.toLowerCase()
 
     for( var i = 0; i < this.refs.length; i++ ) {
-      if( this.refs[ i ][ attr ] && this.refs[ i ][ attr ].toLowerCase() === value ) {
+      if( typeof this.refs[ i ][ attr ] === 'string' && this.refs[ i ][ attr ].toLowerCase() === value ) {
         return true
       }
     }

--- a/lib/link.js
+++ b/lib/link.js
@@ -85,7 +85,7 @@ class Link {
     var type = value.toLowerCase()
 
     for( var i = 0; i < this.refs.length; i++ ) {
-      if( this.refs[ i ].rel.toLowerCase() === type ) {
+      if( this.refs[ i ].rel && this.refs[ i ].rel.toLowerCase() === type ) {
         links.push( this.refs[ i ] )
       }
     }
@@ -108,7 +108,7 @@ class Link {
     var links = []
 
     for( var i = 0; i < this.refs.length; i++ ) {
-      if( this.refs[ i ][ attr ].toLowerCase() === value ) {
+      if( this.refs[ i ][ attr ] && this.refs[ i ][ attr ].toLowerCase() === value ) {
         links.push( this.refs[ i ] )
       }
     }
@@ -142,7 +142,7 @@ class Link {
     value = value.toLowerCase()
 
     for( var i = 0; i < this.refs.length; i++ ) {
-      if( this.refs[ i ][ attr ].toLowerCase() === value ) {
+      if( this.refs[ i ][ attr ] && this.refs[ i ][ attr ].toLowerCase() === value ) {
         return true
       }
     }


### PR DESCRIPTION
This should avoid unnecessary TypeErrors when `rel`, `get`, `has` is not guaranteed to find matching attribute before attempting to operate on the string value.